### PR TITLE
BIO-1379 - remove files downloaded from PDC on successful verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A self contained (aiohttp) REST service that helps verify uploaded SNP&SEQ archi
 
 The web service enqueues certain job functions in the RQ/Redis queue, where they get picked up by the separate RQ worker process. 
 
+The downloaded files are deleted on successful verification, and retained if any error occurs.
+
 Trying it out
 -------------
 
@@ -24,13 +26,16 @@ Mock Downloading
 If you are running this service locally and don't have IBM's dsmc client installed, you can skip the downloading step and verify an archive that is already on your machine.
 
 To use this method:
-- copy an archive that has been pre-downloaded from PDC into the verify_root_dir set in app.yaml
+- copy* an archive that has been pre-downloaded from PDC into the verify_root_dir set in app.yaml
 - Delete or edit some files from the archive if you wish to trigger a validation error.
 - in app.yml, set:
 
 
     pdc_client: "MockPdcClient"
+    
+\*Note that the archive will be deleted from verify_root_dir on successful verification
 
+#### Naming Conventions for Mock Download ####
 Note that when an archive is downloaded from PDC using snpseq-archive-verify, the downloaded directory is formatted with the name of the archive plus the RQ job id, like so:
 
     {verify_root_dir}/{archive_name}_{rq_job_id}

--- a/archive_verify/pdc_client.py
+++ b/archive_verify/pdc_client.py
@@ -1,8 +1,9 @@
-import re
+import fnmatch
 import logging
 import os
+import re
+import shutil
 import subprocess
-import fnmatch
 
 # Share pre-configured workers log
 log = logging.getLogger('archive_verify.workers')
@@ -59,6 +60,9 @@ class PdcClient():
 
     def downloaded_archive_path(self):
         return os.path.join(self.dest(), self.archive_name)
+
+    def cleanup(self):
+        shutil.rmtree(self.dest())
 
     @staticmethod
     def _parse_dsmc_return_code(exit_code, output, whitelist):

--- a/archive_verify/workers.py
+++ b/archive_verify/workers.py
@@ -85,7 +85,8 @@ def verify_archive(archive_name, archive_pdc_path, archive_pdc_description, conf
 
         if verified_ok:
             log.info("Verify of {} succeeded.".format(archive))
-            return {"state": "done", "path": output_file, "msg": "sucessfully verified archive md5sums"}
+            pdc_client.cleanup()
+            return {"state": "done", "path": output_file, "msg": "Successfully verified archive md5sums."}
         else:
             log.info("Verify of {} failed.".format(archive))
-            return {"state": "error", "path": output_file, "msg": "failed to verify archive md5sums"}
+            return {"state": "error", "path": output_file, "msg": "Failed to verify archive md5sums."}

--- a/tests/test_pdc_client.py
+++ b/tests/test_pdc_client.py
@@ -57,3 +57,8 @@ class TestPdcClient(unittest.TestCase):
             mock_parse_dsmc.return_value = exp_ret
             ret = self.getPdcClient().download()
             self.assertEqual(ret, exp_ret)
+
+    def test_cleanup(self):
+        with mock.patch('shutil.rmtree') as mock_rmtree:
+            self.getPdcClient().cleanup()
+            mock_rmtree.assert_called_with("data/verify/archive_1234")


### PR DESCRIPTION
**What problems does this PR solve?**
This PR ensures that files downloaded from PDC are deleted after they have been successfully verified. Please note that this PR is not for merging into master, but into another local branch, which will then in turn be merged to master in a separate PR: https://github.com/Molmed/snpseq-archive-verify/pull/4

**How has the changes been tested?**
New automated tests. Manual testing instructions can be found in the README, and should cover the following scenarios:

- downloaded archive successfully verified, and then deleted
- downloaded archive verification failure, and files are not deleted

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [X ] This PR contains code that could remove data

Downloaded files are deleted. I'd like another set of eyeballs to ensure that nothing nefarious can happen here.